### PR TITLE
Fix test_backend.py when PyTorch is installed

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -10,6 +10,7 @@ import fdtd
 
 try:
     from fdtd.backend import NumpyBackend, TorchBackend
+    skip_test_backend = False
 except ImportError:
     skip_test_backend = True
 


### PR DESCRIPTION
For me if PyTorch is installed, without this patch the test fails with

```
Traceback (most recent call last):
  File ".../test_backend.py", line 20, in <module>
    @pytest.mark.skipif(skip_test_backend, reason="PyTorch is not installed.")
NameError: name 'skip_test_backend' is not defined
```