### PR TITLE
Update pip install

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,11 @@ and linking it with pip
 pip install -e fdtd
 ```
 
+Development dependencies can be installed with
+```
+pip install -e ftdt[dev]
+```
+
 ## Dependencies
 
 - python 3.6+

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ pip install -e fdtd
 
 Development dependencies can be installed with
 ```
-pip install -e ftdt[dev]
+pip install -e fdtd[dev]
 ```
 
 ## Dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-tqdm
-numpy
-scipy
-matplotlib

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,9 +1,0 @@
-pytest
-sphinx
-nbsphinx
-sphinx-rtd-theme
-black
-nbstripout
-pre-commit
-ipykernel
-line_profiler

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import fdtd
 import setuptools
 
 description = """a 3D electromagnetic FDTD simulator written in Python"""
@@ -6,10 +5,13 @@ description = """a 3D electromagnetic FDTD simulator written in Python"""
 with open("readme.md", "r") as file:
     long_description = file.read()
 
+author = "Floris laporte"
+version = "0.0.2"
+
 setuptools.setup(
-    name=fdtd.__name__,
-    version=fdtd.__version__,
-    author=fdtd.__author__,
+    name="fdtd",
+    version=version,
+    author=author,
     author_email="floris.laporte@gmail.com",
     description=description,
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,26 @@ description = """a 3D electromagnetic FDTD simulator written in Python"""
 with open("readme.md", "r") as file:
     long_description = file.read()
 
+reqs = [
+    "tqdm",
+    "numpy",
+    "scipy",
+    "matplotlib",
+]
+
+extras = {
+    "dev": [
+        "pytest",
+        "sphinx",
+        "nbsphinx",
+        "sphinx-rtd-theme",
+        "black",
+        "nbstripout",
+        "pre-commit",
+        "ipykernel",
+        "line_profiler",
+    ]
+}
 author = "Floris laporte"
 version = "0.0.2"
 
@@ -18,6 +38,8 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="http://github.com/flaport/fdtd",
     packages=setuptools.find_packages(),
+    install_requires=reqs,
+    extras_require=extras,
     classifiers=[
         "Programming Language :: Python :: 3",
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
Hey @flaport,
I was looking for a python fdtd library for a term project I am working on, and stumbled upon yours, great work! :) (plus hopefully it will save me from having to use Matlab - haven't even started doing the project yet).

So, I 've made some changes to make the package install using just `pip install fdtd` (or `pip install fdtd[dev]` for dev requirements and, well, a dev install).

To do this I removed any non-setup related imports from the setup.py file, as importing the module itself creates the prerequisite of having the package's dependencies already installed. As for a possible future task, I'd recommend looking into setup.cfg files and possibly a file structure which would have just the package's information in the top level `__init__.py` (i.e. `__author__`, `__name__` etc).

Finally, for versioning I 've used [bump2version](https://pypi.org/project/bump2version/) in the past, and it actually works great. 

Anyway, all of the above can probably be discussed in the Issues and not here.

Any feedback on the changes this PR brings are welcome :)