### PR TITLE
Test workflows PoC

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,22 @@
+# This workflow runs tests for fdtd package.
+
+name: fdtd tests
+
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install test dependencies
+        run: |
+          python -m pip install -U pip
+          pip install -e .[test]
+      - name: Run pytest
+        run: |
+          pytest

--- a/setup.py
+++ b/setup.py
@@ -15,15 +15,20 @@ reqs = [
 extras = {
     "dev": [
         "pytest",
-        "sphinx",
-        "nbsphinx",
-        "sphinx-rtd-theme",
         "black",
         "nbstripout",
         "pre-commit",
         "ipykernel",
         "line_profiler",
-    ]
+    ],
+    "test": [
+        "pytest",
+    ],
+    "docs": [
+        "sphinx",
+        "nbsphinx",
+        "sphinx-rtd-theme",
+    ],
 }
 author = "Floris laporte"
 version = "0.0.2"


### PR DESCRIPTION
(#19)
With these changes, a github Action will run on any push to the repo, triggering unit tests. This can be modified to run only on selected branches, PRs etc.
I 've also split the `dev` dependencies into: `dev`, `docs` and `test` to avoid the added overhead of packages not needed for testing (now that i think about it, `pip install . && pip install pytest` would be good at this stage too). 