### PR TITLE
automated type promotion with complex permeability

### DIFF
--- a/fdtd/backend.py
+++ b/fdtd/backend.py
@@ -99,6 +99,9 @@ class NumpyBackend(Backend):
 
     float = numpy.float64
     """ floating type for array """
+    
+    complex = numpy.complex128
+    """ complex type for array """
 
     # methods
     asarray = _replace_float(numpy.asarray)
@@ -200,6 +203,12 @@ if TORCH_AVAILABLE:
 
         float = torch.get_default_dtype()
         """ floating type for array """
+
+        if float is torch.float32:
+            complex = torch.complex64
+        else:
+            complex = torch.complex128
+        """ complex type for array """
 
         # methods
         asarray = staticmethod(torch.as_tensor)

--- a/fdtd/boundaries.py
+++ b/fdtd/boundaries.py
@@ -103,6 +103,17 @@ class Boundary:
         Note:
             this method is called *after* the grid fields are updated
         """
+    def promote_dtypes_to_complex(self):
+        self.phi_E = bd.complex(self.phi_E)
+        self.phi_H = bd.complex(self.phi_H)
+
+        self.psi_Ex = bd.complex(self.psi_Ex)
+        self.psi_Ey = bd.complex(self.psi_Ey)
+        self.psi_Ez = bd.complex(self.psi_Ez)
+        
+        self.psi_Hx = bd.complex(self.psi_Hx)
+        self.psi_Hy = bd.complex(self.psi_Hy)
+        self.psi_Hz = bd.complex(self.psi_Hz)
 
     def __repr__(self):
         return f"PML(name={repr(self.name)})"

--- a/fdtd/grid.py
+++ b/fdtd/grid.py
@@ -37,7 +37,7 @@ def curl_E(E: Tensorlike) -> Tensorlike:
     Returns:
         The curl of E (H-type field located on the faces of the grid [half-integer grid points])
     """
-    curl = bd.zeros(E.shape)
+    curl = bd.zeros(E.shape,dtype=E.dtype)
 
     curl[:, :-1, :, 0] += E[:, 1:, :, 2] - E[:, :-1, :, 2]
     curl[:, :, :-1, 0] -= E[:, :, 1:, 1] - E[:, :, :-1, 1]
@@ -62,7 +62,7 @@ def curl_H(H: Tensorlike) -> Tensorlike:
         The curl of H (E-type field located on the edges of the grid [integer grid points])
 
     """
-    curl = bd.zeros(H.shape)
+    curl = bd.zeros(H.shape,dtype=H.dtype)
 
     curl[:, 1:, :, 0] += H[:, 1:, :, 2] - H[:, :-1, :, 2]
     curl[:, :, 1:, 0] -= H[:, :, 1:, 1] - H[:, :, :-1, 1]
@@ -263,7 +263,7 @@ class Grid:
             time = tqdm(time)
         for _ in time:
             self.step()
-
+    
     def step(self):
         """do a single FDTD step by first updating the electric field and then
         updating the magnetic field
@@ -349,6 +349,11 @@ class Grid:
         """add an object to the grid"""
         obj._register_grid(self)
         self.objects[name] = obj
+    
+    def promote_dtypes_to_complex(self):
+        self.E = self.E.astype(bd.complex)
+        self.H = self.H.astype(bd.complex)
+        [boundary.promote_dtypes_to_complex() for boundary in self.boundaries]
 
     def __setitem__(self, key, attr):
         if not isinstance(key, tuple):

--- a/fdtd/visualization.py
+++ b/fdtd/visualization.py
@@ -309,7 +309,7 @@ def visualize(
     cmap_norm = None
     if norm == "log":
         cmap_norm = LogNorm(vmin=1e-4, vmax=grid_energy.max() + 1e-4)
-    plt.imshow(bd.numpy(grid_energy), cmap=cmap, interpolation="sinc", norm=cmap_norm)
+    plt.imshow(abs(bd.numpy(grid_energy)), cmap=cmap, interpolation="sinc", norm=cmap_norm)
 
     # finalize the plot
     plt.ylabel(xlabel)


### PR DESCRIPTION
Hey,
i want to add the capability of simulating metals, with complex refractive index. 

The proposed changes just promote the Field and Boundary to Complex type, if a complex permittivity has passed. 
Not sure if it's just enough to make it physically correct?

One simple test to see the effect of complex epsilon:

*complex epsilon*
![complex epsilon](https://github.com/flaport/fdtd/assets/45470500/c191cf34-cbea-40e0-807c-a02e69c90a35)

*real epsilon*
![real epsilon](https://github.com/flaport/fdtd/assets/45470500/9538ae8d-6ce5-4e0e-a639-5348a37397cf)
