### PR TITLE
Fix SoftArbitraryPointSource initialization (detector name issue)

### DIFF
--- a/fdtd/sources.py
+++ b/fdtd/sources.py
@@ -590,7 +590,7 @@ class SoftArbitraryPointSource:
         self.x, self.y, self.z = grid._handle_tuple((x, y, z))
 
         if self.name is not None:
-            detector_name += "_I"
+            detector_name = self.name + "_I"
         else:
             detector_name = None
 


### PR DESCRIPTION
`detector_name` is not initialized anywhere causing issues during initialization